### PR TITLE
Switch to mozilla/sbt image as builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build image
-FROM bitbucketpipelines/scala-sbt:scala-2.12 as builder 
+FROM mozilla/sbt:8u212_1.2.8 as builder
 
 RUN apt-get update
 


### PR DESCRIPTION
The currently used `bitbucketpipelines/scala-sbt` seems a bit abandoned and does not currently build:

```
Step 2/10 : RUN apt-get update
 ---> Running in 8f9f8181158b
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [7340 B]
Ign http://deb.debian.org jessie-backports InRelease
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Ign http://deb.debian.org jessie-backports Release.gpg
Get:4 http://deb.debian.org jessie Release [148 kB]
Ign http://deb.debian.org jessie-backports Release
Err http://deb.debian.org jessie-backports/main amd64 Packages

Err http://deb.debian.org jessie-backports/main amd64 Packages

Err http://deb.debian.org jessie-backports/main amd64 Packages

Err http://deb.debian.org jessie-backports/main amd64 Packages

Err http://deb.debian.org jessie-backports/main amd64 Packages
  404  Not Found
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [851 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.2 MB in 8s (1169 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

W: Failed to fetch http://deb.debian.org/debian/dists/jessie-backports/main/binary-amd64/Packages  404  Not Found

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update' returned a non-zero code: 100
```

This switches to an image maintained by Mozilla, using which the docker image builds successfully.