### PR TITLE
Censor pii

### DIFF
--- a/src/main/scala/ai/diffy/DiffyServiceModule.scala
+++ b/src/main/scala/ai/diffy/DiffyServiceModule.scala
@@ -90,7 +90,10 @@ object DiffyServiceModule extends TwitterModule {
 
   val maxResponseSize =
     flag[String]("maxResponseSize", "5.megabytes", "StorageUnit value like 5.megabytes")
-  
+
+  val sensitiveParameters =
+    flag( "sensitiveParameters", "", "Do not allow these values to be saved or viewed")
+
   @Provides
   @Singleton
   def settings =
@@ -130,7 +133,8 @@ object DiffyServiceModule extends TwitterModule {
         .map(new ResourceMatcher(_)),
       responseMode = ServiceInstance.from(responseMode()).getOrElse(ServiceInstance.Primary),
       maxHeaderSize = StorageUnit.parse(maxHeaderSize()),
-      maxResponseSize = StorageUnit.parse(maxResponseSize())
+      maxResponseSize = StorageUnit.parse(maxResponseSize()),
+      sensitiveParameters = sensitiveParameters().split(',').filter(_.size > 0).toSet
     )
 
   @Provides

--- a/src/main/scala/ai/diffy/lifter/HttpLifter.scala
+++ b/src/main/scala/ai/diffy/lifter/HttpLifter.scala
@@ -1,9 +1,16 @@
 package ai.diffy.lifter
 
+import java.util.AbstractMap
+
+import ai.diffy.lifter.StringLifter.htmlRegexPattern
 import ai.diffy.util.ResourceMatcher
-import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.http.{ParamMap, Request, Response}
 import com.twitter.logging.Logger
 import com.twitter.util.{Future, Try}
+import java.util.{AbstractMap, Map => JMap, List => JList}
+import scala.collection.JavaConverters._
+
+import scala.util.control.NoStackTrace
 
 
 object HttpLifter {
@@ -21,22 +28,42 @@ object HttpLifter {
   }
 }
 
-class HttpLifter(excludeHttpHeadersComparison: Boolean, resourceMatcher: Option[ResourceMatcher] = None) {
+class HttpLifter(excludeHttpHeadersComparison: Boolean, resourceMatcher: Option[ResourceMatcher] = None, sensitiveParameters: Option[Set[String]] = None) {
+
   import HttpLifter._
 
   private[this] val log = Logger(classOf[HttpLifter])
+
   private[this] def headersMap(response: Response): Map[String, Any] = {
-    if(!excludeHttpHeadersComparison) {
+    if (!excludeHttpHeadersComparison) {
       val rawHeaders = response.headerMap.toSeq
 
       val headers = rawHeaders map { case (name, value) =>
         (name.toLowerCase, value)
-      } groupBy { _._1} map { case (name, pairs) =>
-        name -> (pairs map { _._2 } sorted)
+      } groupBy {
+        _._1
+      } map { case (name, pairs) =>
+        name -> (pairs map {
+          _._2
+        } sorted)
       }
 
-      Map( "headers" -> FieldMap(headers))
+      Map("headers" -> FieldMap(headers))
     } else Map.empty
+  }
+
+  def liftSensitiveParams(sensitive: Set[String], req: Request) : (JList[JMap.Entry[String, String]], String) =
+  {
+    val splitBit = req.uri.split("\\?", 2)
+    val redactedURI = splitBit(0) + (if (splitBit.length == 1) "" else "?" +
+      redactContainer(splitBit(1).split('&').map(bit => {
+        val stuff = bit.split("=", 2)
+        if (stuff.size > 1) (stuff(0), stuff(1)) else (stuff(0), "")
+      }), sensitive).map { case (key: String, value: String) => key + '=' + value }.mkString("&"))
+    val redactedParameters = redactContainer(req.params, sensitive).toList.map {
+      case (k, v) => new AbstractMap.SimpleImmutableEntry(k, v).asInstanceOf[JMap.Entry[String, String]]
+    }
+    (redactedParameters.asJava, redactedURI)
   }
 
   def liftRequest(req: Request): Future[Message] = {
@@ -46,14 +73,18 @@ class HttpLifter(excludeHttpHeadersComparison: Boolean, resourceMatcher: Option[
       .get("Canonical-Resource")
       .orElse(resourceMatcher.flatMap(_.resourceName(req.path)))
 
-    val params = req.getParams()
-    val body = StringLifter.lift(req.getContentString())
+    val (params: JList[JMap.Entry[String, String]], uri) = (sensitiveParameters match {
+      case None => (req.getParams(), req.uri)
+      case Some(sensitive) => liftSensitiveParams(sensitive, req)
+    })
+
+    val body = liftBody(req.getContentString())
     Future.value(
       Message(
         canonicalResource,
         FieldMap(
           Map(
-            "uri" -> req.uri,
+            "uri" -> uri,
             "method" -> req.method,
             "headers" -> headers,
             "params" -> params,
@@ -64,6 +95,60 @@ class HttpLifter(excludeHttpHeadersComparison: Boolean, resourceMatcher: Option[
     )
   }
 
+
+  object KeyValParseError extends Exception with NoStackTrace
+
+  // Converts a key = value representation to something Diffy can understand
+  def liftText(string: String): Any = {
+    val asMap = string.split('\n').foldLeft( Map.empty[String,Any] )(
+      (map, line) =>
+      {
+        val index = line indexOf '='
+        if (index == -1)
+          throw KeyValParseError
+        val startString: String = line.substring(0, index).trim()
+        val endString: String  = line.substring(index + 1).trim()
+        val endBit = Try(JsonLifter.lift(JsonLifter.decode(endString))).getOrElse(endString)
+        map + (startString -> (map.get(startString) match {
+          case Some(a: Seq[Any]) => (a :+ endBit)
+          case Some(a: Any) => Seq(a, endBit)
+          case None => endBit
+        }))
+      })
+    FieldMap(asMap)
+  }
+
+  def redactContainer[T >: String](traversable: TraversableOnce[(String, T)], sensitive: Set[String]): TraversableOnce[(String, T)] =
+  {
+    traversable.map { case (key: String, value) =>
+      (key,
+        if (sensitive.contains(key))
+          value match {
+            case strVal: String => strVal.map(_ => 'x')
+            case _ => "redacted"
+          }
+        else
+          value)
+    }
+  }
+
+  def redactBody(unredacted: Any): Any = {
+    (sensitiveParameters, unredacted) match {
+      case (Some(sensitive), fieldMap: FieldMap[Any])  => FieldMap(redactContainer(fieldMap, sensitive).toMap)
+      case _ => unredacted
+    }
+  }
+
+  def liftBody(string: String): Any = {
+    Try(FieldMap(Map("type" -> "json", "value" -> redactBody(JsonLifter.lift(JsonLifter.decode(string)))))).getOrElse {
+      Try(FieldMap(Map("type" -> "text", "value" -> redactBody(liftText(string))))).getOrElse {
+        if (htmlRegexPattern.findFirstIn(string).isDefined)
+          FieldMap(Map("type" -> "html", "value" -> HtmlLifter.lift(HtmlLifter.decode(string))))
+        else string
+      }
+    }
+  }
+
   def liftResponse(resp: Try[Response]): Future[Message] = {
     log.debug(s"$resp")
     Future.const(resp) flatMap { r: Response =>
@@ -72,7 +157,7 @@ class HttpLifter(excludeHttpHeadersComparison: Boolean, resourceMatcher: Option[
       val controllerEndpoint = r.headerMap.get(ControllerEndpointHeaderName)
 
       val stringContentTry = Try {
-        StringLifter.lift(r.getContentString())
+        liftBody(r.getContentString())
       }
 
       Future.const(stringContentTry map { stringContent =>

--- a/src/main/scala/ai/diffy/proxy/HttpDifferenceProxy.scala
+++ b/src/main/scala/ai/diffy/proxy/HttpDifferenceProxy.scala
@@ -19,7 +19,8 @@ object HttpDifferenceProxy {
 trait HttpDifferenceProxy extends DifferenceProxy {
   import HttpDifferenceProxy._
   val servicePort: SocketAddress
-  val lifter = new HttpLifter(settings.excludeHttpHeadersComparison, settings.resourceMatcher)
+  val lifter = new HttpLifter(settings.excludeHttpHeadersComparison, settings.resourceMatcher,
+    if (settings.sensitiveParameters.nonEmpty) Option(settings.sensitiveParameters) else None)
 
   override type Req = Request
   override type Rep = Response

--- a/src/main/scala/ai/diffy/proxy/Settings.scala
+++ b/src/main/scala/ai/diffy/proxy/Settings.scala
@@ -34,4 +34,5 @@ case class Settings(
     resourceMatcher: Option[ResourceMatcher] = None,
     responseMode: ServiceInstance = ServiceInstance.Primary,
     maxResponseSize: StorageUnit,
-    maxHeaderSize: StorageUnit)
+    maxHeaderSize: StorageUnit,
+    sensitiveParameters: Set[String])

--- a/src/test/scala/ai/diffy/TestHelper.scala
+++ b/src/test/scala/ai/diffy/TestHelper.scala
@@ -35,7 +35,8 @@ object TestHelper extends MockitoSugar {
     useFramedThriftTransport = false,
     responseMode = ServiceInstance.Primary,
     maxHeaderSize = StorageUnit.fromKilobytes(32),
-    maxResponseSize = StorageUnit.fromMegabytes(5)
+    maxResponseSize = StorageUnit.fromMegabytes(5),
+    sensitiveParameters = Set[String]()
   )
 
   def makeEmptyJoinedDifferences = {


### PR DESCRIPTION
Added parsing for key=value based inputs and outputs.
This is currently picked after JSON and before HTML.

Added sensitiveParameters option to allow it to automatically redact various top-level parameters from the request. This is useful for protecting the privacy of user data that has gone through diffy. Users can "opt-out" of collecting various parameters on the command line and they will be replaced with "XXXXXXX" of the same length if string, or "redacted" if structured.