### PR TITLE
Load 5 minute data instead of 24 hour data as default

### DIFF
--- a/frontend/src/features/selections/selectionsSlice.ts
+++ b/frontend/src/features/selections/selectionsSlice.ts
@@ -18,7 +18,7 @@ const initialState: Selections = {
     infoIsOpen: false,
     deleteRequestAlertIsOpen: false,
     requestIsOpen: false,
-    dateTimeRange: {start: Date.now() - 24*3600*1000, end: Date.now()}
+    dateTimeRange: {start: Date.now() - 5*60*1000, end: Date.now()} // last 5 minute
 };
 const slice = createSlice({
     name: 'selections',


### PR DESCRIPTION
Currently, FE loads 24-hour data as a default. If the data volume is high and the response to the requests is complex, the server crashes because of high memory usage. Latency is also very high. 

I set the default loading interval to last 5 minutes. if users wants to extend the filter, they can do.