### PR TITLE
fix(frontend): update mui Tree* dependency for FieldsView.tsx

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.10.9",
     "@mui/lab": "^5.0.0-alpha.104",
     "@mui/material": "^5.10.10",
+    "@mui/x-tree-view": "^7.12.0",
     "@reduxjs/toolkit": "^1.8.6",
     "@types/lodash": "^4.14.186",
     "@wojtekmaj/react-datetimerange-picker": "^5.2.0",

--- a/frontend/src/features/fields/FieldsView.tsx
+++ b/frontend/src/features/fields/FieldsView.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { List, ListItem, ListItemText, ListSubheader, Switch, Stack, Tooltip, Typography, IconButton} from '@mui/material';
-import {TreeView, TreeItem} from '@mui/lab';
+import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
 import {ExpandMore, ChevronRight} from '@mui/icons-material';
 
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
@@ -37,7 +37,7 @@ export function FieldsView(){
     function renderTree(node: FieldNode, tree: any, noDiff: boolean) {
         return <TreeItem
           key={node.id}
-          nodeId={node.id}
+          itemId={node.id}
           label={label(selectedEndpoint, node, tree, noDiff)}
           onClick={() => dispatch(selectFieldPrefix(node.id))}
           disabled={ disabledNode === node.id }
@@ -89,19 +89,23 @@ export function FieldsView(){
         return `${metric.name}: ${metric.differences} diffs | ${metric.noise/(metric.differences)*100.00}% noise/diffs`
       }
     return       (<List subheader={<ListSubheader>Fields</ListSubheader>}>
-          <TreeView
-      defaultCollapseIcon={<ExpandMore />}
-      defaultExpanded={['request']}
-      defaultExpandIcon={<ChevronRight />}
-    >
-      {request && renderTree(request, tree, true)}
-    </TreeView>
-    <TreeView
-      defaultCollapseIcon={<ExpandMore />}
-      defaultExpanded={['response']}
-      defaultExpandIcon={<ChevronRight />}
-    >
+      <SimpleTreeView
+        slots={{
+          expandIcon: ExpandMore,
+          collapseIcon: ChevronRight,
+        }}
+        defaultExpandedItems={['request']}
+      >
+        {request && renderTree(request, tree, true)}
+      </SimpleTreeView>
+      <SimpleTreeView
+        slots={{
+          expandIcon: ExpandMore,
+          collapseIcon: ChevronRight,
+        }}
+        defaultExpandedItems={['request']}
+      >
       {response && renderTree(response, tree, false)}
-    </TreeView>
+    </SimpleTreeView>
   </List>);
 }


### PR DESCRIPTION
# Description

I've been using `opendiffy/diffy` and building from source with some customization. Upon doing so I've noticed the default frontend `@mui/lab` _Tree*_ components have been deprecated and now must be imported from `@mui/x-tree-view` with _TreeView_ having been renamed to _SimpleTreeView_ as well as some slight changes in component props to both _SimpleTreeView_ and _TreeItem_.

## Changes

Adds `@mui/x-tree-view` as frontend dependency and replace _TreeView_ & _TreeItem_ to be imported from aforementioned package with migrated syntax following the following docs:
- https://mui.com/blog/lab-tree-view-to-mui-x/
- https://mui.com/x/migration/migration-tree-view-v6/

## Bug Reproduction & Testing Change

One can verify the bug by standing up the docker-compose stack, building the diffy image from source locally by replacing [L53 in docker-compose.yml](https://github.com/opendiffy/diffy/blob/61b9f70e12ca6412677c65bf32d90659d74f1795/docker-compose.yml#L53) with something like:

```yml
    image: local_diffy:latest
    build:
      context: .
      dockerfile: Dockerfile 
```

On `master`:
1. stand up docker compose stack locally building diffy from source following the above modification to the compose file, ex. `docker compose -p diffy-local -f docker-compose.yml up --build`
2. make a request to the diffy server at 8880 (request failure doesn't matter for this bug reproduction), ex.

        curl -v -X --url="http://localhost:8880"

4. navigate to the frontend at http://localhost:8888
5. clicking on the entry on the left hand *Endpoints* list will show nothing under right side *Fields* and there will be a warning in the developer console about the deprecation, see screenshot:

![Screenshot 2024-08-06 at 12 08 51 AM](https://github.com/user-attachments/assets/31876cb6-6678-42ad-a56b-60598d39fd3e)

Do the same on this branch (building diffy image from source) and it will work as it did before, screenshot for reference:

![Screenshot 2024-08-06 at 12 57 35 AM](https://github.com/user-attachments/assets/05c6fc84-2c66-4d95-afea-17848bc19765)

## Additional Context & Consideration

The current [diff/diffy:latest](https://hub.docker.com/r/diffy/diffy) image, does not have this problem likely due to a frontend docker build cache with a `@mui/lab` version prior to the deprecation.

It might be worth considering adding a frontend dependency lock file so this issue does not arise for future users who choose to build from source.