### PR TITLE
feat: use mongodb instead of embedded mongo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build image
-FROM maven:3.8.6-openjdk-18 as builder
+FROM maven:3.8-eclipse-temurin-17-focal AS builder
 ENV HOME=/usr/local/src
 RUN mkdir -p $HOME
 WORKDIR $HOME
@@ -27,7 +27,7 @@ RUN mv target /target
 RUN mv agent /agent
 
 # production image
-FROM maven:3.8.6-openjdk-18
+FROM maven:3.8-eclipse-temurin-17-focal
 COPY --from=builder /target/diffy.jar /diffy.jar
 COPY --from=builder /agent/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
 ENTRYPOINT ["java", "-javaagent:opentelemetry-javaagent.jar", "-jar", "diffy.jar"]

--- a/docker-compose-dependencies.yml
+++ b/docker-compose-dependencies.yml
@@ -1,6 +1,20 @@
 version: "3.8"
 
 services:
+  mongodb:
+    image: mongo
+    container_name: mongodb
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=pass12345
+    ports:
+      - 27017:27017
+    healthcheck:
+      test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    restart: unless-stopped
 
   loki:
     image: grafana/loki:2.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: "3.8"
 
 services:
+  mongodb:
+    image: mongo
+    container_name: mongodb
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=pass12345
+    ports:
+      - 27017:27017
+    healthcheck:
+      test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    restart: unless-stopped
 
   loki:
     image: grafana/loki:2.2.0
@@ -56,6 +70,11 @@ services:
       - "8880:8880"
 #    env_file: "./diffy.env"
     environment:
+      spring.data.mongodb.authentication-database: admin
+      spring.data.mongodb.host: "mongodb"
+      spring.data.mongodb.port: 27017
+      spring.data.mongodb.username: root
+      spring.data.mongodb.password: pass12345
       candidate: "candidate:5000"
       master.primary: "primary:5000"
       master.secondary: "secondary:5000"
@@ -86,6 +105,7 @@ services:
       - ./data/logs:/app/logs
     depends_on:
       - tempo
+      - mongodb
       - primary
       - secondary
       - candidate

--- a/localdev.properties
+++ b/localdev.properties
@@ -1,3 +1,8 @@
+spring.data.mongodb.authentication-database=admin
+spring.data.mongodb.host=http://localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.username=root
+spring.data.mongodb.password=pass12345
 candidate=localhost:9000
 master.primary=localhost:9100
 master.secondary=localhost:9200

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
-<!--        For osx M1 Chip support see https://github.com/opendiffy/diffy/issues/68 -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
@@ -154,6 +153,7 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <version>3.4.9</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Updated the example and changed POM to allow for a deployed mongodb, this also enables the use of cloud based mongodbs, self maintained, or use of any API compatible document db.

The docker compose for local testing/experimentation was also updated to have the mongodb added to it, it has some hardcoded credentials for local development so be mindful of that.

PS.: The embedded mongo is a source of frustration, and the fact that this project requires it present, and alot of why it doest not work is because it needs a certain environment, a certain OS, a certain library, etc, and it is not all already fixed and present inside the Docker build process, also there is a common want for deploying with a dedicated mongo DB that is shared between multiple pods, then to me it is important that this version exist.